### PR TITLE
Omit nulls by default

### DIFF
--- a/NServiceBus.PostgreSQL.Benchmarks/Program.cs
+++ b/NServiceBus.PostgreSQL.Benchmarks/Program.cs
@@ -15,10 +15,10 @@
         private static void Main(string[] args)
         {
             var client = new Client("10.211.55.2");
-            Stats.MethodExecuted += (sender, info) => client.SendEvent(info.MethodBase.ToString(), String.Empty, String.Empty, (float)info.TimeSpan.TotalMilliseconds);
+            Stats.MethodExecuted += (sender, info) => client.SendEvent(info.MethodBase.ToString(), String.Empty, String.Empty, (float)info.TimeSpan.Ticks / 10);
             WireUpHistograms();
             var benchmarks = new IBenchmark[] {new SagaPersisterBenchmark(), new OutboxPersisterBenchmark(), new TimeoutPersisterBenchmark() };
-            const int iterations = 100000;
+            const int iterations = 1000;
             Console.WriteLine("Executing benchmarks. Please wait...");
             const string outfile = "log.csv";
             var writeheaders = !File.Exists(outfile);

--- a/NServiceBus.PostgreSQL/NServiceBus.PostgreSQL.csproj
+++ b/NServiceBus.PostgreSQL/NServiceBus.PostgreSQL.csproj
@@ -57,6 +57,7 @@
     <Compile Include="Outbox\OutboxPersister.cs" />
     <Compile Include="Outbox\PostgreSQLOutboxStorage.cs" />
     <Compile Include="PostgreSQLPersistence.cs" />
+    <Compile Include="Serializer.cs" />
     <Compile Include="TimeAttribute.cs" />
     <Compile Include="Saga\PostgreSQLSagaStorage.cs" />
     <Compile Include="PostgreSQLStorageSession.cs" />

--- a/NServiceBus.PostgreSQL/Outbox/OutboxPersister.cs
+++ b/NServiceBus.PostgreSQL/Outbox/OutboxPersister.cs
@@ -12,6 +12,7 @@ namespace NServiceBus.PostgreSQL.Outbox
     public class OutboxPersister : IOutboxStorage
     {
         static readonly ILog Logger = LogManager.GetLogger(typeof(OutboxPersister));
+        private static readonly Serializer _serializer = new Serializer();
         private readonly Func<IDbConnection> _connectionFactory;
 
         public OutboxPersister(ConnectionFactoryHolder connectionFactoryHolder)
@@ -47,7 +48,7 @@ namespace NServiceBus.PostgreSQL.Outbox
             using (var conn = _connectionFactory())
             {
                 var p = new DynamicParameters(new {messageId});
-                p.Add(":transportoperations", JsonConvert.SerializeObject(transportOperations), DbType.String);
+                p.Add(":transportoperations", _serializer.Serialize(transportOperations), DbType.String);
                 conn.Execute(
                     "INSERT INTO outboxes(messageId, transportoperations) VALUES (:messageId, :transportoperations)",
                     p);

--- a/NServiceBus.PostgreSQL/Outbox/OutboxPersister.cs
+++ b/NServiceBus.PostgreSQL/Outbox/OutboxPersister.cs
@@ -6,12 +6,11 @@ namespace NServiceBus.PostgreSQL.Outbox
     using System.Linq;
     using Dapper;
     using Logging;
-    using Newtonsoft.Json;
     using NServiceBus.Outbox;
 
     public class OutboxPersister : IOutboxStorage
     {
-        static readonly ILog Logger = LogManager.GetLogger(typeof(OutboxPersister));
+        private static readonly ILog Logger = LogManager.GetLogger(typeof (OutboxPersister));
         private static readonly Serializer _serializer = new Serializer();
         private readonly Func<IDbConnection> _connectionFactory;
 
@@ -26,7 +25,8 @@ namespace NServiceBus.PostgreSQL.Outbox
             using (var conn = _connectionFactory())
             {
                 message =
-                    conn.Query<string>("SELECT transportoperations FROM outboxes WHERE messageId = :messageId", new { messageId })
+                    conn.Query<string>("SELECT transportoperations FROM outboxes WHERE messageId = :messageId",
+                        new {messageId})
                         .Select(
                             r =>
                             {
@@ -34,7 +34,7 @@ namespace NServiceBus.PostgreSQL.Outbox
                                 if (r != null)
                                 {
                                     m.TransportOperations.AddRange(
-                                        JsonConvert.DeserializeObject<List<TransportOperation>>(r));
+                                        _serializer.Deserialize<List<TransportOperation>>(r));
                                 }
                                 return m;
                             }).FirstOrDefault();

--- a/NServiceBus.PostgreSQL/Saga/SagaPersister.cs
+++ b/NServiceBus.PostgreSQL/Saga/SagaPersister.cs
@@ -6,9 +6,7 @@
     using System.Linq;
     using Dapper;
     using Logging;
-    using Newtonsoft.Json;
     using NServiceBus.Saga;
-    using Outbox;
 
     public class SagaPersister : ISagaPersister
     {
@@ -55,7 +53,7 @@
                 p.Add(":id", dbType: DbType.Guid, value: sagaId);
                 var data =
                     conn.Query<string>("SELECT sagadata FROM sagas WHERE type = :type AND id = :id", p).FirstOrDefault();
-                return data == default(string) ? default(TSagaData) : JsonConvert.DeserializeObject<TSagaData>(data);
+                return data == default(string) ? default(TSagaData) : _serializer.Deserialize<TSagaData>(data);
             }
         }
         [Time]
@@ -71,7 +69,7 @@
                 var data =
                     conn.Query<string>("SELECT sagadata FROM sagas WHERE type = :type AND sagadata @> :jsonString", p)
                         .FirstOrDefault();
-                return data == default(string) ? default(TSagaData) : JsonConvert.DeserializeObject<TSagaData>(data);
+                return data == default(string) ? default(TSagaData) : _serializer.Deserialize<TSagaData>(data);
             }
         }
         [Time]

--- a/NServiceBus.PostgreSQL/Serializer.cs
+++ b/NServiceBus.PostgreSQL/Serializer.cs
@@ -11,5 +11,10 @@
         {
             return JsonConvert.SerializeObject(o, JsonSerializerSettings);
         }
+
+        public T Deserialize<T>(string contents)
+        {
+            return JsonConvert.DeserializeObject<T>(contents, JsonSerializerSettings);
+        }
     }
 }

--- a/NServiceBus.PostgreSQL/Serializer.cs
+++ b/NServiceBus.PostgreSQL/Serializer.cs
@@ -1,0 +1,15 @@
+﻿namespace NServiceBus.PostgreSQL
+{
+    using System;
+    using Newtonsoft.Json;
+
+    class Serializer
+    {
+        private static readonly JsonSerializerSettings JsonSerializerSettings = new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore };
+
+        public string Serialize(Object o)
+        {
+            return JsonConvert.SerializeObject(o, JsonSerializerSettings);
+        }
+    }
+}

--- a/NServiceBus.PostgreSQL/Timeout/TimeoutPersister.cs
+++ b/NServiceBus.PostgreSQL/Timeout/TimeoutPersister.cs
@@ -8,10 +8,12 @@ namespace NServiceBus.PostgreSQL.Timeout
     using Logging;
     using Newtonsoft.Json;
     using NServiceBus.Timeout.Core;
+    using Outbox;
 
     public class TimeoutPersister : IPersistTimeouts
     {
         static readonly ILog Logger = LogManager.GetLogger(typeof(TimeoutPersister));
+        private static readonly Serializer _serializer = new Serializer();
         private readonly Func<IDbConnection> _connectionFactory;
 
         public TimeoutPersister(ConnectionFactoryHolder connectionFactoryHolder)
@@ -61,7 +63,7 @@ namespace NServiceBus.PostgreSQL.Timeout
                     timeout.Time,
                     EndpointName
                 });
-                timeoutInfo.Add("Headers", JsonConvert.SerializeObject(timeout.Headers));
+                timeoutInfo.Add("Headers", _serializer.Serialize(timeout.Headers));
                 conn.Execute(
                     "INSERT INTO timeouts (id, destination, sagaid, state, time, headers, endpointname) VALUES (:Id, :Destination, :SagaId, :State, :Time, :Headers, :EndpointName)",
                     timeoutInfo);

--- a/NServiceBus.PostgreSQL/Timeout/TimeoutPersister.cs
+++ b/NServiceBus.PostgreSQL/Timeout/TimeoutPersister.cs
@@ -6,9 +6,7 @@ namespace NServiceBus.PostgreSQL.Timeout
     using System.Linq;
     using Dapper;
     using Logging;
-    using Newtonsoft.Json;
     using NServiceBus.Timeout.Core;
-    using Outbox;
 
     public class TimeoutPersister : IPersistTimeouts
     {
@@ -88,7 +86,7 @@ namespace NServiceBus.PostgreSQL.Timeout
                                     Destination = i.destination != null ? Address.Parse(i.destination) : null,
                                     SagaId = i.sagaid,
                                     State = i.state,
-                                    Headers = JsonConvert.DeserializeObject<Dictionary<string, string>>(i.headers),
+                                    Headers = _serializer.Deserialize<Dictionary<string, string>>(i.headers),
                                     OwningTimeoutManager = i.endpointname
                                 }).FirstOrDefault();
                 var result = timeoutData != default(TimeoutData);


### PR DESCRIPTION
Omit nulls from serialized JSON to help performance over the wire as well as on disk for sparsly populated documents.
